### PR TITLE
Rename Branch View to Refs View

### DIFF
--- a/tig-cheat-sheet.tex
+++ b/tig-cheat-sheet.tex
@@ -78,7 +78,7 @@
 \section{Switch between views}
 \begin{tabular}{@{}ll ll ll@{}}
 \verb!m! & \verb!Main!. & \verb!p! & \verb!Pager!. & \verb!t! & \verb!Directory! tree.\\
-\verb!d! & \verb!Diff!. & \verb!H! & \verb!Branch!. & \verb!f! & \verb!File! blob.\\
+\verb!d! & \verb!Diff!. & \verb!r! & \verb!Refs!. & \verb!f! & \verb!File! blob.\\
 \verb!l! & \verb!Log!. & \verb!S! & \verb!Status!. & \verb!y! & \verb!Stash!.\\
 \verb!B! & \verb!Blame!. & \verb!c! & \verb!Stage!. & \verb!h! & \verb!Help!.\\
 \end{tabular}
@@ -145,7 +145,7 @@
 \verb!,! & Load blame for the parent commit (Parent is queried for merges). \\
 \end{tabular}
 
-\section{Branch View(H)}
+\section{Refs View(r)}
 \begin{tabular}{@{}lp{6.5cm}@{}}
 \verb!Enter! & Open commit log view. \\
 \verb!C! & Checkout current branch (e.g. git checkout \%(branch)). \\


### PR DESCRIPTION
In tig 2.0 the branch view has been renamed to the
refs view. It now shows tags as well.
